### PR TITLE
Introduce stream data type

### DIFF
--- a/bvm/ballerina-core/pom.xml
+++ b/bvm/ballerina-core/pom.xml
@@ -117,6 +117,14 @@
             <groupId>org.atomikos.wso2</groupId>
             <artifactId>atomikos</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.ballerina.messaging</groupId>
+            <artifactId>broker-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.ballerina.messaging</groupId>
+            <artifactId>broker-core</artifactId>
+        </dependency>
 
         <!-- Siddhi Stream Dependencies -->
         <dependency>

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
@@ -57,6 +57,7 @@ import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BNewArray;
 import org.ballerinalang.model.values.BRefType;
 import org.ballerinalang.model.values.BRefValueArray;
+import org.ballerinalang.model.values.BStream;
 import org.ballerinalang.model.values.BStreamlet;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BStringArray;
@@ -685,6 +686,12 @@ public class BLangVM {
                     cpIndex = operands[1];
                     typeRefCPEntry = (TypeRefCPEntry) constPool[cpIndex];
                     sf.refRegs[i] = new BTable(typeRefCPEntry.getType());
+                    break;
+                case InstructionCodes.NEWSTREAM:
+                    i = operands[0];
+                    cpIndex = operands[1];
+                    typeRefCPEntry = (TypeRefCPEntry) constPool[cpIndex];
+                    sf.refRegs[i] = new BStream(typeRefCPEntry.getType());
                     break;
                 case InstructionCodes.NEWSTREAMLET:
                     createNewStreamlet(operands, sf);

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/BStreamType.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/BStreamType.java
@@ -21,18 +21,19 @@ import org.ballerinalang.model.values.BStream;
 import org.ballerinalang.model.values.BValue;
 
 /**
- * {@code BStreamType} represents tabular data in Ballerina.
+ * {@code BStreamType} represents streaming data in Ballerina.
  *
- * @since 0.8.0
+ * @since 0.964.0
  */
 public class BStreamType extends BType {
 
     private BType constraint;
 
     /**
-     * Create a {@code BStreamType} which represents the SQL Result Set.
+     * Creates a {@code BStreamType} which represents the stream type.
      *
-     * @param typeName string name of the type
+     * @param typeName  string name of the type
+     * @param pkgPath   package path
      */
     BStreamType(String typeName, String pkgPath) {
         super(typeName, pkgPath, BStream.class);
@@ -54,7 +55,7 @@ public class BStreamType extends BType {
 
     @Override
     public <V extends BValue> V getEmptyValue() {
-        return (V) new BStream();
+        return null; //TODO:check - return (V) new BStream();
     }
 
     @Override

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/TypeEnum.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/types/TypeEnum.java
@@ -38,7 +38,6 @@ import static org.ballerinalang.model.types.TypeConstants.REFTYPE_TSIG;
 import static org.ballerinalang.model.types.TypeConstants.STREAMLET_TNAME;
 import static org.ballerinalang.model.types.TypeConstants.STREAMLET_TSIG;
 import static org.ballerinalang.model.types.TypeConstants.STREAM_TNAME;
-import static org.ballerinalang.model.types.TypeConstants.STREAM_TSIG;
 import static org.ballerinalang.model.types.TypeConstants.STRING_TNAME;
 import static org.ballerinalang.model.types.TypeConstants.STRING_TSIG;
 import static org.ballerinalang.model.types.TypeConstants.STRUCT_TNAME;
@@ -66,7 +65,7 @@ public enum TypeEnum {
     TABLE(TABLE_TNAME, REFTYPE_TSIG),
     VOID(VOID_TNAME, VOID_TSIG),
     STRUCT(STRUCT_TNAME, STRUCT_TSIG),
-    STREAM(STREAM_TNAME, STREAM_TSIG),
+    STREAM(STREAM_TNAME, REFTYPE_TSIG),
     STREAMLET(STREAMLET_TNAME, STREAMLET_TSIG),
     ANY(ANY_TNAME, ANY_TSIG),
     ARRAY(ARRAY_TNAME, ARRAY_TSIG),

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BStream.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BStream.java
@@ -19,22 +19,42 @@
 package org.ballerinalang.model.values;
 
 
+import io.ballerina.messaging.broker.core.BrokerException;
+import io.ballerina.messaging.broker.core.Consumer;
+import io.ballerina.messaging.broker.core.ContentChunk;
+import io.ballerina.messaging.broker.core.Message;
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.bre.bvm.WorkerContext;
+import org.ballerinalang.model.types.BStreamType;
+import org.ballerinalang.model.types.BStructType;
 import org.ballerinalang.model.types.BType;
 import org.ballerinalang.model.types.BTypes;
+import org.ballerinalang.model.util.JSONUtils;
+import org.ballerinalang.util.BrokerUtils;
+import org.ballerinalang.util.exceptions.BallerinaException;
+import org.ballerinalang.util.program.BLangFunctions;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 
 /**
  * The {@code BStream} represents a stream in Ballerina.
  *
- * @since 0.8.0
+ * @since 0.964.0
  */
-
-//TODO Check this file and refine
 public class BStream implements BRefType<Object> {
 
+    private BStructType constraintType;
 
-    @Override
-    public Object value() {
-        return null;
+    private String topicName;
+
+    public BStream(BType type) {
+        if (((BStreamType) type).getConstrainedType() == null) {
+            throw  new BallerinaException("A stream cannot be created without a constraint");
+        }
+        this.constraintType = (BStructType) ((BStreamType) type).getConstrainedType();
+        //temporarily until topic name is set to identifier name
+        this.topicName = "TOPIC_NAME_" + UUID.randomUUID();
     }
 
     @Override
@@ -50,6 +70,86 @@ public class BStream implements BRefType<Object> {
     @Override
     public BValue copy() {
         return null;
+    }
+
+    @Override
+    public Object value() {
+        return null;
+    }
+
+    /**
+     * Method to publish to a topic representing the stream in the broker.
+     *
+     * @param data  the data to publish to the stream
+     */
+    public void publish(BStruct data) {
+        if (data.getType() != this.constraintType) {
+            throw new BallerinaException("Incompatible Types: struct of type:" + data.getType().getName()
+                                             + " cannot be added to a stream of type:" + this.constraintType.getName());
+        }
+        BrokerUtils.publish(topicName, JSONUtils.convertStructToJSON(data).stringValue().getBytes());
+    }
+
+    /**
+     * Method to register a subscription to the underlying topic representing the stream in the broker.
+     *
+     * @param context           the context object representing runtime state
+     * @param functionPointer   represents the funtion pointer reference for the function to be invoked on receiving
+     *                          messages
+     */
+    public void subscribe(Context context, BFunctionPointer functionPointer) {
+        String queueName = String.valueOf(System.currentTimeMillis());
+        BrokerUtils.addSubscription(topicName, new StreamSubscriber(queueName, context, functionPointer));
+    }
+
+    private class StreamSubscriber extends Consumer {
+
+        final String queueName;
+        final Context context;
+        final BFunctionPointer functionPointer;
+
+        StreamSubscriber(String queueName, Context context, BFunctionPointer functionPointer) {
+            this.queueName = queueName;
+            this.context = context;
+            this.functionPointer = functionPointer;
+        }
+
+        @Override
+        protected void send(Message message) throws BrokerException {
+            byte[] bytes = new byte[0];
+            for (ContentChunk chunk:message.getContentChunks()) {
+                bytes = new byte[chunk.getBytes().readableBytes()];
+                chunk.getBytes().getBytes(0, bytes);
+            }
+            BJSON json = new BJSON(new String(bytes, StandardCharsets.UTF_8));
+//            BStruct data = JSONUtils.convertJSONToStruct(json, constraintType); TODO: replace with rebase
+            BStruct data = JSONUtils.convertJSONToStruct(json, constraintType,
+                                             context.getProgramFile().getEntryPackage());
+            BValue[] args = {data};
+            Context workerContext = new WorkerContext(context.getProgramFile(), context);
+            BLangFunctions.invokeFunction(context.getProgramFile(), functionPointer.value().getFunctionInfo(), args,
+                                          workerContext);
+        }
+
+        @Override
+        public String getQueueName() {
+            return queueName;
+        }
+
+        @Override
+        protected void close() throws BrokerException {
+
+        }
+
+        @Override
+        public boolean isExclusive() {
+            return false;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
     }
 
 }

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/BrokerUtils.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/BrokerUtils.java
@@ -1,0 +1,113 @@
+package org.ballerinalang.util;
+
+import io.ballerina.messaging.broker.common.StartupContext;
+import io.ballerina.messaging.broker.common.ValidationException;
+import io.ballerina.messaging.broker.common.config.BrokerCommonConfiguration;
+import io.ballerina.messaging.broker.common.config.BrokerConfigProvider;
+import io.ballerina.messaging.broker.common.data.types.FieldTable;
+import io.ballerina.messaging.broker.core.Broker;
+import io.ballerina.messaging.broker.core.BrokerException;
+import io.ballerina.messaging.broker.core.Consumer;
+import io.ballerina.messaging.broker.core.ContentChunk;
+import io.ballerina.messaging.broker.core.Message;
+import io.ballerina.messaging.broker.core.Metadata;
+import io.ballerina.messaging.broker.core.configuration.BrokerCoreConfiguration;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Class providing utility methods to interact with the broker operating in in-memory mode.
+ * TODO: Needs refactoring once the broker core is moved to the Ballerina core
+ */
+public class BrokerUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(BrokerUtils.class);
+
+    private static Broker broker;
+
+    static {
+        startupBroker();
+    }
+
+    /**
+     * Method to add a subscription to the broker operating in in-memory mode.
+     *
+     * @param topic     the topic for which the subscription is registered
+     * @param consumer  the consumer to register for the subscription
+     */
+    public static void addSubscription(String topic, Consumer consumer) {
+        String queueName = consumer.getQueueName(); //need to rely on implementers of consumers to specify unique names
+        try {
+            broker.createQueue(queueName, false, false, true);
+            broker.bind(queueName, "amq.topic", topic, FieldTable.EMPTY_TABLE);
+            broker.addConsumer(consumer);
+        } catch (BrokerException | ValidationException e) {
+            logger.error("Error adding subscription: ", e);
+        }
+    }
+
+    /**
+     * Method to publish to a topic in the broker operating in in-memory mode.
+     *
+     * @param topic     the topic for which the subscription is registered
+     * @param payload   the payload to publish (message content)
+     */
+    public static void publish(String topic, byte[] payload) {
+        Message message = new Message(broker.getNextMessageId(),
+                                      new Metadata(topic, "amq.topic", payload.length));
+        ByteBuf content = Unpooled.copiedBuffer(payload);
+        message.addChunk(new ContentChunk(0, content));
+        Message newMessage = message.shallowCopyWith(broker.getNextMessageId(), topic, "amq.topic");
+        try {
+            broker.publish(newMessage);
+        } catch (BrokerException e) {
+            logger.error("Error publishing to topic: ", e);
+        }
+    }
+
+    /**
+     * Method to start up the Ballerina Broker. TODO: change
+     */
+    private static void startupBroker() {
+        BallerinaBrokerConfigProvider configProvider = new BallerinaBrokerConfigProvider();
+        BrokerCommonConfiguration brokerCommonConfiguration = new BrokerCommonConfiguration();
+        brokerCommonConfiguration.setEnableInMemoryMode(true);
+        configProvider.registerConfigurationObject(BrokerCommonConfiguration.NAMESPACE, brokerCommonConfiguration);
+        BrokerCoreConfiguration brokerCoreConfiguration = new BrokerCoreConfiguration();
+        brokerCoreConfiguration.setDurableQueueInMemoryCacheLimit("1000");
+        configProvider.registerConfigurationObject(BrokerCoreConfiguration.NAMESPACE, brokerCoreConfiguration);
+        StartupContext startupContext = new StartupContext();
+        startupContext.registerService(BrokerConfigProvider.class, configProvider);
+
+        try {
+            broker = new Broker(startupContext);
+        } catch (Exception e) {
+            logger.error("Error occurred initializing the in-memory broker: ", e);
+        }
+        broker.startMessageDelivery();
+    }
+
+    /**
+     * Configuration provider implementation.
+     */
+    private static class BallerinaBrokerConfigProvider implements BrokerConfigProvider {
+
+        private Map<String, Object> configMap = new HashMap<>();
+
+        @Override
+        public <T> T getConfigurationObject(String namespace, Class<T> configurationClass) throws Exception {
+            return configurationClass.cast(configMap.get(namespace));
+        }
+
+        void registerConfigurationObject(String namespace, Object configObject) {
+            configMap.put(namespace, configObject);
+        }
+
+    }
+
+}

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/Mnemonics.java
@@ -231,6 +231,7 @@ public class Mnemonics {
         mnemonics[InstructionCodes.NEWMAP] = "newmap";
         mnemonics[InstructionCodes.NEWJSON] = "newjson";
         mnemonics[InstructionCodes.NEWTABLE] = "newtable";
+        mnemonics[InstructionCodes.NEWSTREAM] = "newstream";
 
         mnemonics[InstructionCodes.NEW_INT_RANGE] = "new_int_range";
         mnemonics[InstructionCodes.ITR_NEW] = "itr_new";

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/ProgramFileReader.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/util/codegen/ProgramFileReader.java
@@ -921,6 +921,7 @@ public class ProgramFileReader {
             case 'T':
             case 'E':
             case 'D':
+            case 'H':
                 char typeChar = chars[index];
                 // TODO Improve this logic
                 index++;
@@ -1029,6 +1030,8 @@ public class ProgramFileReader {
                         return BTypes.typeJSON;
                     } else if (ch == 'D') {
                         return BTypes.typeTable;
+                    } else if (ch == 'H') { //TODO:CHECK
+                        return BTypes.typeStream;
                     }
                 }
 
@@ -1461,7 +1464,6 @@ public class ProgramFileReader {
                 case InstructionCodes.ERRSTORE:
                 case InstructionCodes.TR_END:
                 case InstructionCodes.NEWMAP:
-                case InstructionCodes.NEWSTREAM:
                     i = codeStream.readInt();
                     packageInfo.addInstruction(InstructionFactory.get(opcode, i));
                     break;
@@ -1531,6 +1533,7 @@ public class ProgramFileReader {
                 case InstructionCodes.SNE_NULL:
                 case InstructionCodes.NEWJSON:
                 case InstructionCodes.NEWTABLE:
+                case InstructionCodes.NEWSTREAM:
                 case InstructionCodes.NEWSTREAMLET:
                     i = codeStream.readInt();
                     j = codeStream.readInt();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/codegen/CodeGenerator.java
@@ -95,6 +95,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLang
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangMapLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangRecordKey;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangRecordKeyValue;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangStreamLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangStructLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangTableLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
@@ -764,6 +765,13 @@ public class CodeGenerator extends BLangNodeVisitor {
         tableLiteral.regIndex = calcAndGetExprRegIndex(tableLiteral);
         Operand typeCPIndex = getTypeCPIndex(tableLiteral.type);
         emit(InstructionCodes.NEWTABLE, tableLiteral.regIndex, typeCPIndex);
+    }
+
+    @Override
+    public void visit(BLangStreamLiteral streamLiteral) {
+        streamLiteral.regIndex = calcAndGetExprRegIndex(streamLiteral);
+        Operand typeCPIndex = getTypeCPIndex(streamLiteral.type);
+        emit(InstructionCodes.NEWSTREAM, streamLiteral.regIndex, typeCPIndex);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -77,6 +77,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangJSONLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangMapLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangStreamLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangStructLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangTableLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
@@ -522,6 +523,8 @@ public class Desugar extends BLangNodeVisitor {
             result = new BLangMapLiteral(recordLiteral.keyValuePairs, recordLiteral.type);
         } else if (recordLiteral.type.tag == TypeTags.TABLE) {
             result = new BLangTableLiteral(recordLiteral.type);
+        } else if (recordLiteral.type.tag == TypeTags.STREAM) {
+            result = new BLangStreamLiteral(recordLiteral.type);
         } else if (recordLiteral.type.tag == TypeTags.STREAMLET) {
             result = new BLangRecordLiteral.BLangStreamletLiteral(recordLiteral.type);
         } else {
@@ -657,6 +660,7 @@ public class Desugar extends BLangNodeVisitor {
             case TypeTags.XML:
             case TypeTags.MAP:
             case TypeTags.TABLE:
+            case TypeTags.STREAM:
             case TypeTags.STRUCT:
                 List<BLangExpression> argExprs = new ArrayList<>(iExpr.argExprs);
                 argExprs.add(0, iExpr.expr);
@@ -1121,6 +1125,7 @@ public class Desugar extends BLangNodeVisitor {
             case TypeTags.XML:
                 return;
             case TypeTags.TABLE:
+            case TypeTags.STREAM:
                 // TODO: add this once the able initializing is supported.
                 return;
             default:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -999,6 +999,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 && varType.tag != TypeTags.XML
                 && varType.tag != TypeTags.MAP
                 && varType.tag != TypeTags.TABLE
+                && varType.tag != TypeTags.STREAM
                 && varType.tag != TypeTags.STRUCT) {
             dlog.error(funcNode.receiver.pos, DiagnosticCode.FUNC_DEFINED_ON_NOT_SUPPORTED_TYPE,
                     funcNode.name.value, varType.toString());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStreamType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStreamType.java
@@ -24,9 +24,9 @@ import org.wso2.ballerinalang.compiler.util.TypeDescriptor;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 /**
- * {@code BStreamType} represents tabular data in Ballerina.
+ * {@code BStreamType} represents stream data in Ballerina.
  *
- * @since 0.961.0
+ * @since 0.964.0
  */
 public class BStreamType extends BBuiltInRefType implements ConstrainedType {
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNodeVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNodeVisitor.java
@@ -59,6 +59,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangJSONLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangMapLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangStreamLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangStructLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral.BLangTableLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
@@ -561,6 +562,10 @@ public abstract class BLangNodeVisitor {
     }
 
     public void visit(BLangTableLiteral tableLiteral) {
+        throw new AssertionError();
+    }
+
+    public void visit(BLangStreamLiteral streamLiteral) {
         throw new AssertionError();
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangRecordLiteral.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangRecordLiteral.java
@@ -198,6 +198,23 @@ public class BLangRecordLiteral extends BLangExpression implements RecordLiteral
     }
 
     /**
+     * This class represents a stream type literal expression.
+     *
+     * @since 0.964.0
+     */
+    public static class BLangStreamLiteral extends BLangRecordLiteral {
+
+        public BLangStreamLiteral(BType streamType) {
+            this.type = streamType;
+        }
+
+        @Override
+        public void accept(BLangNodeVisitor visitor) {
+            visitor.visit(this);
+        }
+    }
+
+    /**
      * This class represents a streamlet type literal expression.
      *
      * @since 0.963.0

--- a/pom.xml
+++ b/pom.xml
@@ -703,7 +703,16 @@
                 <artifactId>metrics-core</artifactId>
                 <version>${metrics.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>io.ballerina.messaging</groupId>
+                <artifactId>broker-common</artifactId>
+                <version>${broker.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.ballerina.messaging</groupId>
+                <artifactId>broker-core</artifactId>
+                <version>${broker.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1270,6 +1279,7 @@
         <jackson-core.version>2.8.6</jackson-core.version>
         <apache.mina.core>2.0.16</apache.mina.core>
         <mimepull.version>1.9.7</mimepull.version>
+        <broker.version>0.1.20</broker.version>
 
         <wso2.maven.compiler.source>1.8</wso2.maven.compiler.source>
         <wso2.maven.compiler.target>1.8</wso2.maven.compiler.target>
@@ -1312,7 +1322,7 @@
         <apache.source.release.assembly.descriptor.version>1.0.5</apache.source.release.assembly.descriptor.version>
         <awaitility.version>3.0.0</awaitility.version>
 
-        <siddhi.version>4.1.11-SNAPSHOT</siddhi.version>
+        <siddhi.version>4.1.11</siddhi.version>
         <metrics.version>3.1.0</metrics.version>
         <disruptor.version>3.3.2.wso2v2</disruptor.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/builtin/streamletlib.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/builtin/streamletlib.bal
@@ -1,0 +1,12 @@
+package ballerina.builtin;
+
+@Description {value:"Execute a test function"}
+@Return { value:"Return value"}
+public native function executeQuery (string sqlQuery);
+
+
+@Description {value:"Push event to Siddhi runtime."}
+@Param {value:"st: The streamlet object"}
+@Param {value:"streamId: A string that specifies a streamId"}
+@Param {value:"eventBody: Event body"}
+public native function pushEvent (any st, string streamId, any eventBody);

--- a/stdlib/ballerina-builtin/src/main/ballerina/ballerina/builtin/streamlib.bal
+++ b/stdlib/ballerina-builtin/src/main/ballerina/ballerina/builtin/streamlib.bal
@@ -1,12 +1,27 @@
+// Copyright (c) 2018 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ballerina.builtin;
 
-@Description {value:"Execute a test function"}
-@Return { value:"Return value"}
-public native function executeQuery (string sqlQuery);
+@Description {value:"Publish a struct to the stream"}
+@Param {value:"s: The stream to which publishing is to be done"}
+@Param {value:"data: The struct with data, to be published"}
+public native function <stream s> publish (any data);
 
-
-@Description {value:"Push event to Siddhi runtime."}
-@Param {value:"st: The streamlet object"}
-@Param {value:"streamId: A string that specifies a streamId"}
-@Param {value:"eventBody: Event body"}
-public native function pushEvent (any st, string streamId, any eventBody);
+@Description {value:"Subscribe to structs from a stream"}
+@Param {value:"s: The stream to which subscription is to be done"}
+@Param {value:"func: The function pointer for subscription"}
+public native function <stream s> subscribe (function (any) func);

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/builtin/streamlib/Publish.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/builtin/streamlib/Publish.java
@@ -1,0 +1,51 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.nativeimpl.builtin.streamlib;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BStream;
+import org.ballerinalang.model.values.BStruct;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+
+/**
+ * {@code Publish} is the function to publish data to a stream.
+ *
+ * @since 0.964.0
+ */
+@BallerinaFunction(packageName = "ballerina.builtin",
+        functionName = "stream.publish",
+        args = {
+                @Argument(name = "s", type = TypeKind.STREAM),
+                @Argument(name = "data", type = TypeKind.ANY)
+        },
+        isPublic = true)
+public class Publish extends AbstractNativeFunction {
+
+    @Override
+    public BValue[] execute(Context context) {
+        BStream stream = (BStream) getRefArgument(context, 0);
+        BStruct data = (BStruct) getRefArgument(context, 1);
+        stream.publish(data);
+        return VOID_RETURN;
+    }
+
+}

--- a/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/builtin/streamlib/Subscribe.java
+++ b/stdlib/ballerina-builtin/src/main/java/org/ballerinalang/nativeimpl/builtin/streamlib/Subscribe.java
@@ -1,0 +1,51 @@
+/*
+*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.nativeimpl.builtin.streamlib;
+
+import org.ballerinalang.bre.Context;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.model.values.BFunctionPointer;
+import org.ballerinalang.model.values.BStream;
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.natives.AbstractNativeFunction;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+
+/**
+ * {@code Subscribe} is the function to subscribe to data from a stream.
+ *
+ * @since 0.964.0
+ */
+@BallerinaFunction(packageName = "ballerina.builtin",
+        functionName = "stream.subscribe",
+        args = {
+                @Argument(name = "s", type = TypeKind.STREAM),
+                @Argument(name = "func", type = TypeKind.ANY)
+        },
+        isPublic = true)
+public class Subscribe extends AbstractNativeFunction {
+
+    @Override
+    public BValue[] execute(Context context) {
+        BStream stream = (BStream) getRefArgument(context, 0);
+        BFunctionPointer functionPointer = (BFunctionPointer) getRefArgument(context, 1);
+        stream.subscribe(context, functionPointer);
+        return VOID_RETURN;
+    }
+
+}


### PR DESCRIPTION
## Purpose
Introduce stream data type in Ballerina.

## Goals
Support the stream data type in Ballerina, which allows publishing and subscribing.

## Approach
The stream type is supported based on topics in the broker, where subscribing to a stream would be equivalent to a topic subscription on the broker, and publishing to the stream would correspond to publishing to the topic on the broker.