### PR TITLE
Change stream's topic name to use variable name

### DIFF
--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/bre/bvm/BLangVM.java
@@ -102,6 +102,7 @@ import org.ballerinalang.util.codegen.attributes.AttributeInfo;
 import org.ballerinalang.util.codegen.attributes.AttributeInfoPool;
 import org.ballerinalang.util.codegen.attributes.CodeAttributeInfo;
 import org.ballerinalang.util.codegen.attributes.DefaultValueAttributeInfo;
+import org.ballerinalang.util.codegen.attributes.LocalVariableAttributeInfo;
 import org.ballerinalang.util.codegen.cpentries.ConstantPoolEntry;
 import org.ballerinalang.util.codegen.cpentries.FloatCPEntry;
 import org.ballerinalang.util.codegen.cpentries.FunctionCallCPEntry;
@@ -691,7 +692,11 @@ public class BLangVM {
                     i = operands[0];
                     cpIndex = operands[1];
                     typeRefCPEntry = (TypeRefCPEntry) constPool[cpIndex];
-                    sf.refRegs[i] = new BStream(typeRefCPEntry.getType());
+                    AttributeInfo attributeInfo = sf.workerInfo.getAttributeInfo(
+                            AttributeInfo.Kind.LOCAL_VARIABLES_ATTRIBUTE);
+                    String varName = ((LocalVariableAttributeInfo) attributeInfo)
+                            .getLocalVariableDetails(i).getVariableName();
+                    sf.refRegs[i] = new BStream(typeRefCPEntry.getType(), varName);
                     break;
                 case InstructionCodes.NEWSTREAMLET:
                     createNewStreamlet(operands, sf);

--- a/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BStream.java
+++ b/bvm/ballerina-core/src/main/java/org/ballerinalang/model/values/BStream.java
@@ -35,7 +35,6 @@ import org.ballerinalang.util.exceptions.BallerinaException;
 import org.ballerinalang.util.program.BLangFunctions;
 
 import java.nio.charset.StandardCharsets;
-import java.util.UUID;
 
 /**
  * The {@code BStream} represents a stream in Ballerina.
@@ -44,17 +43,21 @@ import java.util.UUID;
  */
 public class BStream implements BRefType<Object> {
 
+    private static final String TOPIC_NAME_PREFIX = "TOPIC_NAME_";
+
     private BStructType constraintType;
 
+    /**
+     * The name of the underlying broker topic representing the stream object.
+     */
     private String topicName;
 
-    public BStream(BType type) {
+    public BStream(BType type, String identifier) {
         if (((BStreamType) type).getConstrainedType() == null) {
             throw  new BallerinaException("A stream cannot be created without a constraint");
         }
         this.constraintType = (BStructType) ((BStreamType) type).getConstrainedType();
-        //temporarily until topic name is set to identifier name
-        this.topicName = "TOPIC_NAME_" + UUID.randomUUID();
+        this.topicName = TOPIC_NAME_PREFIX + identifier;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
Include the stream's name in the name of the underlying topic representing the stream in the broker.

## Goals
Maintain a mapping between the stream definition and the underlying broker topic.

## Approach
When a stream is initialized, the variable name is identified and used to set the name of the underlying topic representing the stream in the broker. This is the name of the topic (routing key) against which subscriptions will be added and messages will be published.